### PR TITLE
Fixed dependencies in PKGBUILD

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,13 +1,17 @@
 # Maintainer: Steve Seguin <steve@seguin.email>
+# Contributor: Artur Stuhl <150718978+Arthur-Stuhl@users.noreply.github.com>
 
-pkgname=socialstreamninja
+
+_pkgname=socialstreamninja
+pkgname=socialstreamninja-bin
 pkgver=0.3.43
 pkgrel=1
-pkgdesc="Standalone version of Social Stream Ninja - Electron-based application for capturing social media streams"
-arch=('x86_64')
-url="https://github.com/steveseguin/ssn_app"
-license=('GPL3')
-depends=('fuse2' 'gtk3' 'nss' 'libxss' 'libnotify' 'libxtst' 'xdg-utils')
+pkgdesc='Social media content management and analytics platform / AppImage version'
+arch=(x86_64)
+url="https://github.com/steveseguin/social_stream/"
+license=(GPLv3)
+depends=('fuse: Filesystem in Userspace' 'kdialog: a utility for displaying dialog boxes from shell scripts' 'xdg-user-dirs: Required directies for storing user data' 'qt6-base: For KDE style theming' 'qt6-wayland' 'glibc' 'wayland-protocols: extend the functionality of the Wayland core protocol')
+optdepends=('ffmpeg: Video processing support' 'gtk3: For Gnome style theming' 'nss' 'libxss' 'libnotify:Adds fucntionailty for desktop notifications' 'libxtst')
 source=("${pkgname}-${pkgver}.AppImage::https://github.com/steveseguin/ssn_app/releases/download/v${pkgver}/socialstreamninja_linux_v${pkgver}_x86_64.AppImage"
         "socialstreamninja.desktop")
 sha256sums=('SKIP'


### PR DESCRIPTION
Some dependencies were unnecessary for the application to run so I moved those to optional dependencies, I also added Wayland as a dependency since like 90% of Desktops environments are using Wayland instead of X11 and do not come with those sessions by default anymore.