### PR TITLE
Bug fixes for PKGBUILD and version bump

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,7 +1,8 @@
 # Maintainer: Steve Seguin <steve@seguin.email>
+# Contributor: Arthur Stuhl <ArturKauffmann@proton.me>
 
 pkgname=socialstreamninja
-pkgver=0.3.43
+pkgver=0.3.50
 pkgrel=1
 pkgdesc="Standalone version of Social Stream Ninja - Electron-based application for capturing social media streams"
 arch=('x86_64')
@@ -10,11 +11,13 @@ conflicts=('socialstreamninja-bin' 'socialstreamninja-git')
 url="https://github.com/steveseguin/ssn_app"
 license=('GPL3')
 depends=('fuse' 'zlib' 'glibc')
-optdepends=('gtk3: GTK integration' 'nss: Network security services' 'libxss: X11 screensaver extension' 'libnotify: Desktop notifications' 'libxtst: X11 testing')
+optdepends=('gtk3: GTK integration' 'qt6-base: Qt6 framework intergration' 'wayland: A computer display server protocol' 'nss: Network security services' 'libxss: X11 screensaver extension' 'libnotify: Desktop notifications' 'libxtst: X11 testing')
 source=("${pkgname}-${pkgver}.AppImage::https://github.com/steveseguin/social_stream/releases/download/${pkgver}/socialstreamninja_linux_v${pkgver}_x86_64.AppImage"
         "socialstreamninja.desktop")
-sha256sums=('SKIP'
+sha256sums=('fafc305888e058e76b118a756209a162614b37296893c0e4909cdc7cb683c214'
             'SKIP')
+sha512sums=('SKIP'
+           '0409f3ad018ff9d32143340e8be052f3b6f32c17b200e968e1634954a39ef5c3981ebd1c5e099fc604e31722e3f0e5b953965e3726500d7e557d3b7def3e8e7b')
 noextract=("${pkgname}-${pkgver}.AppImage")
 options=('!strip')
 


### PR DESCRIPTION
Hopefully fixed DOS char issue from AUR report had to also delete and re add PKGBUILD because of DOS character formatting issues probably caused by windows see https://aur.archlinux.org/packages/socialstreamninja#comment-1034873, added shasum256/512 checks for both appimage and .desktop files to check for file corruption during download and for security and added few more optdepeds, bumped ver number to 0.3.50. 