### PR TITLE
Fix debugger detachment during WebSocket interceptor usage

### DIFF
--- a/main.js
+++ b/main.js
@@ -11373,6 +11373,9 @@ async function createWindow(args, reuse = false, mainApp = false) {
     const debuggerDetachTimers = new WeakMap();
 
     function scheduleDebuggerDetach(webContents, delayMs = 3000) {
+        if (!webContents.__debuggerOwnedByInput) {
+            return; // Do not detach if we didn't attach it
+        }
         const existing = debuggerDetachTimers.get(webContents);
         if (existing) clearTimeout(existing);
         debuggerDetachTimers.set(webContents, setTimeout(() => {
@@ -11381,6 +11384,7 @@ async function createWindow(args, reuse = false, mainApp = false) {
                 if (webContents.debugger && webContents.debugger.isAttached()) {
                     webContents.debugger.detach();
                 }
+                webContents.__debuggerOwnedByInput = false;
             } catch (_) { }
         }, delayMs));
     }
@@ -11393,6 +11397,7 @@ async function createWindow(args, reuse = false, mainApp = false) {
         return queueDebuggerInput(webContents, async () => {
             if (!webContents.debugger.isAttached()) {
                 webContents.debugger.attach("1.3");
+                webContents.__debuggerOwnedByInput = true;
             }
             await webContents.debugger.sendCommand("Input.dispatchKeyEvent", command);
             scheduleDebuggerDetach(webContents);
@@ -11475,6 +11480,7 @@ async function createWindow(args, reuse = false, mainApp = false) {
                     const cdpPromise = queueDebuggerInput(wc, async () => {
                         if (!wc.debugger.isAttached()) {
                             wc.debugger.attach("1.3");
+                            wc.__debuggerOwnedByInput = true;
                         }
                         if (args.type && ["mousePressed", "mouseReleased", "mouseMoved", "mouseWheel"].includes(args.type)) {
                             const { tab: _tab, ...mouseArgs } = args;


### PR DESCRIPTION
## Description
This pull request improves the management of the Chrome DevTools Protocol (CDP) debugger attachment and detachment for web contents in `main.js`. The main goal is to ensure that the debugger is only detached if it was previously attached by input handling code, preventing unintended detachments.

## Relevant Issue
Sending an input would always detach the Debugger after the input finished. This became unsafe when WS Monitor was introduced since it also relies on the debugger being attached. Thus, the browser script would suddenly stop receiving all WS events and be completely unaware that the Debugger is detached.


## Changes
* Added a `__debuggerOwnedByInput` property to `webContents` to track whether the debugger was attached by input handling logic. This property is set to `true` when the debugger is attached for input events and reset to `false` upon detachment. 
* Updated the `scheduleDebuggerDetach` function to check the `__debuggerOwnedByInput` flag before attempting to detach the debugger, ensuring it only detaches if it was the owner.
* Ensured that the `__debuggerOwnedByInput` property is reset to `false` after detaching the debugger, maintaining correct state tracking.