### PR TITLE
[codex] Handle transient YouTube discovery network errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -3264,10 +3264,11 @@
             }
 
             // Check for new streams
-            const foundNewStreams = await checkYouTubeGroupForNewStreams(groupId);
+            const discoveryResult = await checkYouTubeGroupForNewStreams(groupId);
+            const hadTransientNetworkError = discoveryResult && discoveryResult.type === 'network_error';
 
             // If we found NEW streams, stop checking (not just any streams)
-            if (foundNewStreams) {
+            if (discoveryResult === true) {
                 stopYouTubeGroupAutoCheck(groupId);
                 return;
             }
@@ -3278,7 +3279,10 @@
 
             // Determine next check interval
             let nextInterval;
-            if (backoffState.checkCount < backoffState.intervals.length) {
+            if (hadTransientNetworkError) {
+                const retryIndex = Math.min(backoffState.checkCount, backoffState.intervals.length - 1);
+                nextInterval = backoffState.intervals[retryIndex];
+            } else if (backoffState.checkCount < backoffState.intervals.length) {
                 nextInterval = backoffState.intervals[backoffState.checkCount];
                 backoffState.checkCount++;
             } else {
@@ -3289,7 +3293,11 @@
             const group = stateManager.getGroup(groupId);
             if (group) {
                 const minutes = Math.floor(nextInterval / 60000);
-                console.log(`No new streams found for YouTube group ${group.username}, checking again in ${minutes} minute(s)`);
+                if (hadTransientNetworkError) {
+                    console.log(`Temporary YouTube network issue for group ${group.username}, checking again in ${minutes} minute(s)`);
+                } else {
+                    console.log(`No new streams found for YouTube group ${group.username}, checking again in ${minutes} minute(s)`);
+                }
             }
 
             // Schedule next check
@@ -3327,6 +3335,9 @@
                 }
             } catch (error) {
                 console.error("YouTube group discovery failed:", error);
+                if (typeof isYouTubeDiscoveryNetworkError === 'function' && isYouTubeDiscoveryNetworkError(error)) {
+                    return { type: 'network_error', message: error.message };
+                }
                 return false;
             }
 

--- a/main.js
+++ b/main.js
@@ -8371,6 +8371,17 @@ async function createWindow(args, reuse = false, mainApp = false) {
         }
     });
 
+    function normalizeNodeFetchError(error) {
+        return {
+            status: 500,
+            error: error?.message || String(error || "Unknown fetch error"),
+            code: error?.code || null,
+            errno: error?.errno || null,
+            type: error?.type || null,
+            name: error?.name || null
+        };
+    }
+
     // Keep the synchronous version for backward compatibility
     ipcMain.on("nodefetch", function (eventRet, args) {
         log("NODE FETCHING! (sync)");
@@ -8392,10 +8403,7 @@ async function createWindow(args, reuse = false, mainApp = false) {
             })
             .catch((error) => {
                 console.error("Fetch error:", error);
-                eventRet.returnValue = {
-                    status: 500,
-                    error: error.message
-                };
+                eventRet.returnValue = normalizeNodeFetchError(error);
             });
     });
 
@@ -8417,10 +8425,7 @@ async function createWindow(args, reuse = false, mainApp = false) {
             };
         } catch (error) {
             console.error("Fetch error:", error);
-            return {
-                status: 500,
-                error: error.message
-            };
+            return normalizeNodeFetchError(error);
         }
     });
 

--- a/youtube.js
+++ b/youtube.js
@@ -55,6 +55,42 @@ function sortYouTubeStreams(streams) {
     return sorted;
 }
 
+function isYouTubeTransientNetworkError(value) {
+    const text = [
+        value?.error,
+        value?.message,
+        value?.code,
+        value?.errno,
+        value?.type,
+        typeof value === 'string' ? value : ''
+    ].filter(Boolean).join(' ').toLowerCase();
+
+    if (!text) return false;
+    return [
+        'err_name_not_resolved',
+        'enotfound',
+        'eai_again',
+        'etimedout',
+        'econnreset',
+        'econnrefused',
+        'network timeout',
+        'socket hang up'
+    ].some(token => text.includes(token));
+}
+
+function createYouTubeDiscoveryNetworkError(fetchUrl, response) {
+    const message = response?.error || response?.message || 'Unable to reach YouTube';
+    const error = new Error(`YouTube network/DNS error while fetching ${fetchUrl}: ${message}`);
+    error.code = 'SSAPP_YOUTUBE_DISCOVERY_NETWORK';
+    error.fetchUrl = fetchUrl;
+    error.response = response || null;
+    return error;
+}
+
+function isYouTubeDiscoveryNetworkError(error) {
+    return error && error.code === 'SSAPP_YOUTUBE_DISCOVERY_NETWORK';
+}
+
 function mergeYouTubeStreams(primaryStreams = [], fallbackStreams = [], isShortDefault = false) {
     const combined = [];
     const seenVideoIds = new Set();
@@ -583,6 +619,10 @@ async function handleYouTubeActivation(username, isShortDefault = false, showPro
         }
     } catch (error) {
         console.error("Error in handleYouTubeActivation for " + username + ":", error);
+        if (isYouTubeDiscoveryNetworkError(error)) {
+            Toast.warning("YouTube Network", `Could not reach YouTube while checking ${username}. This looks like a temporary DNS/network issue; try again shortly.`);
+            return { type: 'network_error', message: error.message };
+        }
         if (showPrompts && error.message && !error.message.includes("No video ID found") && !error.message.includes("User cancelled")) {
             // Check if ipcRenderer and window.confirm are available
             if (typeof ipcRenderer !== 'undefined' && ipcRenderer && typeof window.confirm === 'function') {
@@ -1129,6 +1169,9 @@ async function fetchYouTubeDiscoveryHtml(fetchUrl) {
         headers: getYouTubeDiscoveryFetchHeaders(),
         timeout: 15000
     });
+    if (isYouTubeTransientNetworkError(response)) {
+        throw createYouTubeDiscoveryNetworkError(fetchUrl, response);
+    }
     if (response?.status && response.status >= 400) {
         console.warn(`YouTube discovery fetch returned HTTP ${response.status}:`, fetchUrl);
     }
@@ -1339,6 +1382,9 @@ async function fetchYoutube(username, alt = false, options = {}) {
 			return false;
 		} catch (e) {
 			console.error(`Error during YouTube scrape for ${username}:`, e);
+            if (isYouTubeDiscoveryNetworkError(e)) {
+                throw e;
+            }
 			return false;
 		}
 }


### PR DESCRIPTION
## Summary
- Preserves the existing YouTube discovery order; background checks still do not become API-first.
- Adds richer Electron `nodefetch` error metadata so DNS/timeouts keep their real error codes.
- Classifies transient YouTube discovery network failures separately from true "no streams found" results.
- Lets manual activation show a YouTube network warning and lets background auto-check retry without advancing the no-stream backoff state.

## Validation
- `git diff --cached --check`
- `node --check main.js`
- `node --check youtube.js`
- Mocked YouTube discovery checks for API success, DNS failure after API miss, and non-network scrape failure.
- Live permutation pass: 34 live YouTube entries, 204 checks across display/API, display/scrape, handle/API, handle/scrape, channel ID/API, and channel ID/scrape paths. API display-name misses were covered by scrape/handle/channel-ID fallbacks.